### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/hello_world.s
+++ b/exercises/practice/hello-world/hello_world.s
@@ -1,5 +1,5 @@
 .section .rodata
-msg: .string ""
+msg: .string "Goodbye, Mars!"
 
 .text
 .global hello


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46