### PR TITLE
Update largest-series-product generator

### DIFF
--- a/generators/exercises/largest_series_product.py
+++ b/generators/exercises/largest_series_product.py
@@ -30,7 +30,7 @@ def gen_func_body(prop, inp, expected):
         expectations = {}
         expectations["digits input must only contain digits"] = "INVALID_CHARACTER"
         expectations["span must not be negative"] = "NEGATIVE_SPAN"
-        expectations["span must be smaller than string length"] = "INSUFFICIENT_DIGITS"
+        expectations["span must not exceed string length"] = "INSUFFICIENT_DIGITS"
         expected = expectations[expected["error"]]
 
     return f"TEST_ASSERT_EQUAL_INT64({expected}, largest_product({span}, \"{digits}\"));\n"


### PR DESCRIPTION
Note that all tests can be regenerated using

for slug in `ls exercises/practice`; do generators/generate $slug; done