### PR TITLE
Integrate bin/update-from-templates in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,10 @@ repos:
     hooks:
     -   id: clang-format
         exclude_types: [json]
+-   repo: local
+    hooks:
+      - id: update-from-templates
+        name: Check that all exercises use up-to-date copies from templates dir
+        language: system
+        entry: bin/update-from-templates
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,14 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v20.1.0
+    rev: v20.1.3
     hooks:
     -   id: clang-format
         exclude_types: [json]

--- a/bin/update-from-templates
+++ b/bin/update-from-templates
@@ -6,7 +6,7 @@
 
 set -eo pipefail
 
-die() { echo "$*" >&2; exit 1; }
+die() { echo "$*" >&2; exit 3; }
 
 hash_dir() {
     (cd $1 && find . ! -name "*.o" -type f | sort --unique | xargs cat) | md5sum
@@ -38,6 +38,6 @@ for slug in $(ls exercises/practice); do
     fi
 done
 
-[[ ${num_updated} -eq 0 ]] || exit 2
+[[ ${num_updated} -eq 0 ]] || exit 1
 
 echo "Everything up-to-date."


### PR DESCRIPTION
As the title says. Now `bin/update-from-templates` will be run as part of the pre-commit check. If it changes anything, the CI check will fail.