### PR TITLE
makefiles: only override default AS/CC on non-aarch64 platforms

### DIFF
--- a/exercises/practice/acronym/Makefile
+++ b/exercises/practice/acronym/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/affine-cipher/Makefile
+++ b/exercises/practice/affine-cipher/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/all-your-base/Makefile
+++ b/exercises/practice/all-your-base/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/allergies/Makefile
+++ b/exercises/practice/allergies/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/armstrong-numbers/Makefile
+++ b/exercises/practice/armstrong-numbers/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/atbash-cipher/Makefile
+++ b/exercises/practice/atbash-cipher/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/binary-search/Makefile
+++ b/exercises/practice/binary-search/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/bob/Makefile
+++ b/exercises/practice/bob/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/book-store/Makefile
+++ b/exercises/practice/book-store/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/bottle-song/Makefile
+++ b/exercises/practice/bottle-song/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/collatz-conjecture/Makefile
+++ b/exercises/practice/collatz-conjecture/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/darts/Makefile
+++ b/exercises/practice/darts/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/diamond/Makefile
+++ b/exercises/practice/diamond/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/difference-of-squares/Makefile
+++ b/exercises/practice/difference-of-squares/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/dominoes/Makefile
+++ b/exercises/practice/dominoes/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/eliuds-eggs/Makefile
+++ b/exercises/practice/eliuds-eggs/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/food-chain/Makefile
+++ b/exercises/practice/food-chain/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/grains/Makefile
+++ b/exercises/practice/grains/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/hamming/Makefile
+++ b/exercises/practice/hamming/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/hello-world/Makefile
+++ b/exercises/practice/hello-world/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/house/Makefile
+++ b/exercises/practice/house/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/isbn-verifier/Makefile
+++ b/exercises/practice/isbn-verifier/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/isogram/Makefile
+++ b/exercises/practice/isogram/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/kindergarten-garden/Makefile
+++ b/exercises/practice/kindergarten-garden/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/knapsack/Makefile
+++ b/exercises/practice/knapsack/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/largest-series-product/Makefile
+++ b/exercises/practice/largest-series-product/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/leap/Makefile
+++ b/exercises/practice/leap/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/luhn/Makefile
+++ b/exercises/practice/luhn/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/matching-brackets/Makefile
+++ b/exercises/practice/matching-brackets/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/meetup/Makefile
+++ b/exercises/practice/meetup/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/micro-blog/Makefile
+++ b/exercises/practice/micro-blog/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/minesweeper/Makefile
+++ b/exercises/practice/minesweeper/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/nth-prime/Makefile
+++ b/exercises/practice/nth-prime/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/nucleotide-count/Makefile
+++ b/exercises/practice/nucleotide-count/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/pangram/Makefile
+++ b/exercises/practice/pangram/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/pascals-triangle/Makefile
+++ b/exercises/practice/pascals-triangle/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/perfect-numbers/Makefile
+++ b/exercises/practice/perfect-numbers/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/phone-number/Makefile
+++ b/exercises/practice/phone-number/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/pig-latin/Makefile
+++ b/exercises/practice/pig-latin/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/prime-factors/Makefile
+++ b/exercises/practice/prime-factors/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/proverb/Makefile
+++ b/exercises/practice/proverb/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/pythagorean-triplet/Makefile
+++ b/exercises/practice/pythagorean-triplet/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/queen-attack/Makefile
+++ b/exercises/practice/queen-attack/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/raindrops/Makefile
+++ b/exercises/practice/raindrops/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/rectangles/Makefile
+++ b/exercises/practice/rectangles/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/resistor-color-duo/Makefile
+++ b/exercises/practice/resistor-color-duo/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/resistor-color-trio/Makefile
+++ b/exercises/practice/resistor-color-trio/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/resistor-color/Makefile
+++ b/exercises/practice/resistor-color/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/reverse-string/Makefile
+++ b/exercises/practice/reverse-string/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/rna-transcription/Makefile
+++ b/exercises/practice/rna-transcription/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/roman-numerals/Makefile
+++ b/exercises/practice/roman-numerals/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/rotational-cipher/Makefile
+++ b/exercises/practice/rotational-cipher/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/run-length-encoding/Makefile
+++ b/exercises/practice/run-length-encoding/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/scrabble-score/Makefile
+++ b/exercises/practice/scrabble-score/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/secret-handshake/Makefile
+++ b/exercises/practice/secret-handshake/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/sieve/Makefile
+++ b/exercises/practice/sieve/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/space-age/Makefile
+++ b/exercises/practice/space-age/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/square-root/Makefile
+++ b/exercises/practice/square-root/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/state-of-tic-tac-toe/Makefile
+++ b/exercises/practice/state-of-tic-tac-toe/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/sublist/Makefile
+++ b/exercises/practice/sublist/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/sum-of-multiples/Makefile
+++ b/exercises/practice/sum-of-multiples/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/triangle/Makefile
+++ b/exercises/practice/triangle/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/twelve-days/Makefile
+++ b/exercises/practice/twelve-days/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/two-fer/Makefile
+++ b/exercises/practice/two-fer/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/variable-length-quantity/Makefile
+++ b/exercises/practice/variable-length-quantity/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/exercises/practice/zebra-puzzle/Makefile
+++ b/exercises/practice/zebra-puzzle/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,17 +1,16 @@
+PLATFORM = $(shell uname -m)
+
+ifneq ($(PLATFORM),aarch64)
 ifeq ($(origin AS),default)
 AS = aarch64-linux-gnu-as
 endif
 ifeq ($(origin CC),default)
 CC = aarch64-linux-gnu-gcc
 endif
+endif
 
-CFLAGS ?= -g -Wall -Wextra -pedantic -Werror
-LDFLAGS =
-
-ALL_LDFLAGS = -pie -Wl,--fatal-warnings
-
-ALL_CFLAGS = -std=c99 -fPIE $(CFLAGS)
-ALL_LDFLAGS += $(LDFLAGS)
+CFLAGS ?= -g -Wall -Wextra -pedantic -Werror -std=c99 -fPIE
+LDFLAGS ?= -pie -Wl,--fatal-warnings
 
 C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 AS_OBJS = $(patsubst %.s,%.o,$(wildcard *.s))
@@ -19,18 +18,17 @@ ALL_OBJS = $(filter-out example.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
 
 CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
 
-PLATFORM = $(shell uname -m)
 ifeq ($(PLATFORM),aarch64)
-	MAYBE_QEMU =
+	MAYBE_QEMU ?=
 else
-	MAYBE_QEMU = qemu-aarch64 -L /usr/aarch64-linux-gnu
+	MAYBE_QEMU ?= qemu-aarch64 -L /usr/aarch64-linux-gnu
 endif
 
 all: tests
 	@$(MAYBE_QEMU) ./$<
 
 tests: $(ALL_OBJS)
-	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(ALL_OBJS)
 
 %.o: %.s
 	@$(AS) -o $@ $<


### PR DESCRIPTION
When reviewing one of the other exercises the makefile looked unexpected. Turns out I accidentally had an old version in #173 that would still fail on a native arm64 system that does not use a toolchain prefix of `aarch64-linux-gnu-`. So this would not work with Termux on Android (`aarch64-linux-android-`) and also not on Alpine (`aarch64-alpine-linux-musl-`). The updated version leaves `CC` and `AS` alone on a native aarch64 system. Overriding it from the command line or via environment variables is still possible.

Sorry for missing this earlier!

Also you don't have to go through the trouble of rebasing your open PRs and updating the file there. I can take care of that when reviewing. You've done more than enough here. Thank you!