### PR TITLE
INSTALLATION: mention libc6-dev-arm64-cross

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -11,7 +11,7 @@ sudo apt install gcc make
 If you are not running on ARM64 hardware, install the [QEMU][] emulator and the GCC ARM64 cross-toolchain using
 
 ```shell
-sudo apt install qemu-user gcc-aarch64-linux-gnu
+sudo apt install qemu-user libc6-dev-arm64-cross gcc-aarch64-linux-gnu
 ```
 
 ## Windows


### PR DESCRIPTION
This makes the instructions robust for anybody using `--no-install-recommends`

The following succeeds with ubuntu:26.04

```bash
apt update
apt install --no-install-recommends gcc make
apt install --no-install-recommends qemu-user libc6-dev-arm64-cross gcc-aarch64-linux-gnu

cd .../arm64-assembly
make
```

resolves #224