### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/affine-cipher/.docs/instructions.append.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 If the input is invalid, output an empty string.

--- a/exercises/practice/eliuds-eggs/.docs/instructions.append.md
+++ b/exercises/practice/eliuds-eggs/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Avoid using [CNT](https://developer.arm.com/documentation/ddi0602/2025-06/Base-Instructions/CNT--Count-bits-) for this exercise.

--- a/exercises/practice/game-of-life/.docs/instructions.append.md
+++ b/exercises/practice/game-of-life/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 Each row of the grid is represented as a 64 bit integer.
 
 For example,

--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,4 +1,6 @@
 # Instructions append
 
+## Implementation
+
 Overwrite the supplied phone number string.
 If the phone number is invalid, replace it with an empty string.

--- a/exercises/practice/say/.docs/instructions.append.md
+++ b/exercises/practice/say/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 If the number is out of range, output an empty string.

--- a/exercises/practice/spiral-matrix/.docs/instructions.append.md
+++ b/exercises/practice/spiral-matrix/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 The output should be arranged in [row-major order](https://en.wikipedia.org/wiki/Row-_and_column-major_order): all the words in the first row, then the words in the second row, and so on.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.